### PR TITLE
見てたぞedit版を実装、JSONパスを絶対パスに変更

### DIFF
--- a/lib/editmiteta.py
+++ b/lib/editmiteta.py
@@ -21,7 +21,7 @@ async def mitetazo_edit(before, after):
     before_text = before.content
     after_text = after.content
     composed_text = diff_composer(before_text, after_text)
-    await after.channel(composed_text)
+    await after.channel.send(composed_text)
 
 
 def diff_composer(before_text, after_text):

--- a/lib/editmiteta.py
+++ b/lib/editmiteta.py
@@ -21,7 +21,7 @@ async def mitetazo_edit(before, after):
     before_text = before.content
     after_text = after.content
     composed_text = diff_composer(before_text, after_text)
-    await after.channel.send(composed_text)
+    await after.channel.send("見てたぞ\n```\n{}\n```".format(composed_text))
 
 
 def diff_composer(before_text, after_text):

--- a/lib/editmiteta.py
+++ b/lib/editmiteta.py
@@ -1,0 +1,52 @@
+"""
+クライアントがメッセージの変更を検知したときの処理をします
+例のごとくまたもや関数になりました
+"""
+import difflib
+
+import discord
+
+
+async def mitetazo_edit(before, after):
+    """
+    実際に編集を感知したときに呼ばれる関数
+    編集前のメッセージを送信します
+    Parameters
+    ----------
+    before: discord.Message
+        編集前のMessageオブジェクト
+    after: discord.Message
+        変更後のMessageオブジェクト
+    """
+    before_text = before.content
+    after_text = after.content
+    composed_text = diff_composer(before_text, after_text)
+    await after.channel(composed_text)
+
+
+def diff_composer(before_text, after_text):
+    """
+    beforeとafterのテキストを比較して
+    結果に - + が含まれる行のみをstrで返しますね
+    Parameters
+    ----------
+    before_text: str
+        編集前のMessageオブジェクトのテキスト
+    after_text: str
+        編集後のMessageオブジェクトのテキスト
+    Returns
+    ----------
+    composed_text: str
+        改行なども含め処理をした最終成果物
+    """
+    diff_object = difflib.Differ()
+    diff = diff_object.compare(before_text.split("\n"), after_text.split("\n"))
+    diff_list = list(diff)
+    diff_text_list = [i for i in diff_list if i.startswith("+") or i.startswith("-")]
+    return "\n".join(diff_text_list)
+
+
+if None == "__main__":
+    before_text = "吾輩は猫である。\n名前はまだ無い。\nどこで生まれたかとんと検討がつかぬ。"
+    after_text = "吾輩はカスである。\nうんち\nどこで生まれたかとんと検討がつかぬ。"
+    print(diff_composer(before_text, after_text))

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from lib.time_signal import TimeSignal
 from lib.voice_diff import voice_diff
 from lib.message_debug import message_debug
 from lib.mitetazo import mitetazo
+from lib.editmiteta import mitetazo_edit
 
 from message_command import MessageCommands
 
@@ -56,7 +57,7 @@ class MainClient(discord.Client, Singleton):
 
         # mesm_json_syntax_conceal = 0sages.json (時報json) の読み込みを試みる
         # msg_dictのkeyはstr型です、int型で呼び出そうとしないで()
-        with codecs.open("messages.json", 'r', 'utf-8') as json_file:
+        with codecs.open(os.path.dirname(__file__) + "/messages.json", 'r', 'utf-8') as json_file:
             self.msg_dict = json.loads(json_file.read())
 
     def launch(self):
@@ -115,9 +116,10 @@ class MainClient(discord.Client, Singleton):
         await voice_diff(self.kikisen_channel, member, before, after)
         
     async def on_message_edit(self, before, after):
-        if not after.content.endswith("!d"):
+        if after.content.endswith("!d"):
+            await message_debug(before, after)
             return
-        await message_debug(before, after)
+        await mitetazo_edit(before, after)
 
     async def on_message_delete(self, message: discord.Message):
         await mitetazo(message)

--- a/message_command.py
+++ b/message_command.py
@@ -5,6 +5,7 @@ import re
 import codecs
 import json
 import datetime
+import os
 
 import requests
 import discord
@@ -57,7 +58,7 @@ class MessageCommands:
         self.member_id   = member.id
         self.member_name = member.display_name
 
-        with codecs.open("messages.json", 'r', 'utf-8') as json_file:
+        with codecs.open(os.path.dirname(__file__) + "/messages.json", 'r', 'utf-8') as json_file:
             self.response_dict = json.loads(json_file.read())
 
     async def execute(self):


### PR DESCRIPTION
Approve 1つ以上で Merge
メッセージの編集を検知すると変更のあった行を次の形式で送信します:
```
見てたぞ
+ <変更後の行>
- <変更前の行>
```
弊環境だけかもしれませんが、なぜかmessage.jsonのパスを絶対パスにしないと
`FileNotFoundError: [Errno 2] No such file or directory`と言われるので絶対パスになりました